### PR TITLE
Keep-alive bug fix for server.

### DIFF
--- a/proxy/ReadCloserStats.go
+++ b/proxy/ReadCloserStats.go
@@ -1,0 +1,42 @@
+/*
+Copyright 2019 Comcast Cable Communications Management, LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package proxy
+
+import (
+	"io"
+)
+
+func ReadCloserStats(rc io.ReadCloser) *readCloserStats {
+	return &readCloserStats{rc: rc}
+}
+
+type readCloserStats struct {
+	rc     io.ReadCloser
+	Closed bool
+	Used   bool
+}
+
+func (rcs *readCloserStats) Close() error {
+	rcs.Closed = true
+	rcs.Used = true
+	return rcs.rc.Close()
+}
+
+func (rcs *readCloserStats) Read(p []byte) (n int, err error) {
+	rcs.Used = true
+	return rcs.rc.Read(p)
+}

--- a/proxy/ReadCloserStats_test.go
+++ b/proxy/ReadCloserStats_test.go
@@ -1,0 +1,57 @@
+/*
+Copyright 2019 Comcast Cable Communications Management, LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package proxy
+
+import (
+	"bytes"
+	"io/ioutil"
+	"testing"
+)
+
+func TestReadCloserStats(t *testing.T) {
+	rc := ioutil.NopCloser(bytes.NewReader([]byte("hello world")))
+	rcs := ReadCloserStats(rc)
+	if rc != rcs.rc {
+		t.Errorf("Failed to set up RCS with proper io.ReadCloser")
+	}
+}
+func TestRCSClose(t *testing.T) {
+	rc := ioutil.NopCloser(bytes.NewReader([]byte("hello world")))
+	rcs := ReadCloserStats(rc)
+	if rcs.Closed || rcs.Used {
+		t.Fatalf("readCloserStats not initalized with Closed=false and Used=false")
+	}
+	rcs.Close()
+	if !rcs.Closed || !rcs.Used {
+		t.Fatalf("readCloserStats.Close() does not set Closed and Used to true")
+	}
+
+}
+
+func TestRCSRead(t *testing.T) {
+	rc := ioutil.NopCloser(bytes.NewReader([]byte("hello world")))
+	rcs := ReadCloserStats(rc)
+	if rcs.Closed || rcs.Used {
+		t.Fatalf("readCloserStats not initalized with Closed=false and Used=false")
+	}
+	rcs.Read([]byte{})
+	if !rcs.Used {
+		t.Fatalf("readCloserStats.Read() does not set Used to true")
+	}
+	if rcs.Closed {
+		t.Fatalf("readCloserStats.Read set Closed to true")
+	}
+}

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -130,6 +130,7 @@ var InBlock int64 = 0
 func (p *proxy) listenConn(client *ClientConnProps) {
 	server := &ServerConnProps{
 		ResponseHeaderTimeout: p.ResponseHeaderTimeout,
+		MaxConns:              5,
 	}
 
 	atomic.AddInt64(&clientConns, 1)


### PR DESCRIPTION
## Addresses 
#9

## Description
Fixes the keep-alive issue by adding retry and splitting send and receive errors. Retry is done only on send errors. Adds a connection pool to allow multiple open connections at the same time for a single client connection.

## Additional context

## Checklist
- [x] Your code builds clean without any errors or warnings.
- [x] Device connected through proxy has internet.