### PR TITLE
Resolves #5: adds port selection via command line arguments

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,13 @@
 FROM golang:alpine
 RUN apk update && apk add --virtual build-dependencies build-base git
+ARG EXPOSED_API_PORT=9998
+ARG PROXY_PORT=9999
+ENV A_PORT ${EXPOSED_API_PORT}
+ENV P_PORT ${PROXY_PORT}
 ENV GOPATH /go
 RUN mkdir -p /src/restfulHttpsProxy
 ADD . /src/restfulHttpsProxy
 WORKDIR /src/restfulHttpsProxy
-EXPOSE 9999
-EXPOSE 9998
-CMD ["make"]
+EXPOSE ${EXPOSED_API_PORT}
+EXPOSE ${PROXY_PORT}
+CMD make EXPOSED_API_PORT=${A_PORT} PROXY_PORT=${P_PORT}

--- a/main.go
+++ b/main.go
@@ -25,6 +25,7 @@ import (
 	"io/ioutil"
 	"log"
 	"net/http"
+	"os"
 	"restfulHttpsProxy/proxy"
 	"restfulHttpsProxy/prxConfig"
 	"restfulHttpsProxy/rewriteLogic"
@@ -318,8 +319,8 @@ func main() {
 		},
 	)
 	go launchSessionCleaner(time.Minute, time.Hour*48)
-	go launchExposedAPI(":9998")
-	prx.Listen(":9999")
+	go launchExposedAPI(":" + os.Args[1])
+	prx.Listen(":" + os.Args[2])
 }
 
 func launchExposedAPI(host string) error {

--- a/makefile
+++ b/makefile
@@ -21,7 +21,7 @@ EXPOSED_API_PORT=9998
 PROXY_PORT=9999
 
 run: build
-				./$(TARGET)
+				./$(TARGET) $(EXPOSED_API_PORT) $(PROXY_PORT)
 build:
 				$(GOCMD) build -o $(TARGET) -v
 test:
@@ -35,7 +35,12 @@ longTermDeploy: build
 
 #Docker targets
 docker-image:
-				docker build -t $(DOCKER_LOCAL_IMAGE) .
+				docker build -t $(DOCKER_LOCAL_IMAGE) \
+				--build-arg EXPOSED_API_PORT=$(EXPOSED_API_PORT) \
+				--build-arg PROXY_PORT=$(PROXY_PORT) .
 
 docker-run:
-				docker run -t -p 9999:9999 -p 9998:9998 -i $(DOCKER_LOCAL_IMAGE)
+				docker run -t \
+				-p $(PROXY_PORT):$(PROXY_PORT) \
+				-p $(EXPOSED_API_PORT):$(EXPOSED_API_PORT) \
+				-i $(DOCKER_LOCAL_IMAGE)


### PR DESCRIPTION
Resolves #5:
- main.go now accepts command line arguments (via [os.Args](https://golang.org/pkg/os/)), replacing hardcoded port numbers.
- Dockerfile now accepts [build-time variables](https://docs.docker.com/engine/reference/commandline/build/#set-build-time-variables---build-arg) and sets additional environment variables, which replace hardcoded port numbers.
- Executing `make` (i.e. `make run`) passes the values of the pre-existing `EXPOSED_API_PORT` and `PROXY_PORT` variables to main.go and to Dockerfile.

Examples of use:
```
$ make EXPOSED_API_PORT=9996 PROXY_PORT=9997
```
```
$ make docker-image EXPOSED_API_PORT=9996 PROXY_PORT=9997
$ make docker-run EXPOSED_API_PORT=9996 PROXY_PORT=9997
```
```
$ make docker-image EXPOSED_API_PORT=9995
$ make docker-run
```